### PR TITLE
chore: modernize addon templates for HA 2025

### DIFF
--- a/.README.j2
+++ b/.README.j2
@@ -40,11 +40,8 @@ Use the following URL to add this repository:
 ### &#10003; [{{ addon.name }}][addon-{{ addon.target }}]
 
 ![Latest Version][{{ addon.target }}-version-shield]
-![Supports armhf Architecture][{{ addon.target }}-armhf-shield]
-![Supports armv7 Architecture][{{ addon.target }}-armv7-shield]
 ![Supports aarch64 Architecture][{{ addon.target }}-aarch64-shield]
 ![Supports amd64 Architecture][{{ addon.target }}-amd64-shield]
-![Supports i386 Architecture][{{ addon.target }}-i386-shield]
 
 {{ addon.description }}
 
@@ -68,7 +65,7 @@ add-on, represents the version number.
 [addon-doc-{{ addon.target}}]: {{ addon.repo }}/blob/{{ addon.version }}/README.md
 [{{ addon.target }}-issue]: {{ addon.repo }}/issues
 [{{ addon.target }}-version-shield]: https://img.shields.io/badge/version-{{ addon.version }}-blue.svg
-{% for arch in ['aarch64', 'amd64', 'armhf', 'armv7', 'i386'] %}
+{% for arch in ['aarch64', 'amd64'] %}
 {% if arch in addon.archs %}
 [{{ addon.target }}-{{ arch }}-shield]: https://img.shields.io/badge/{{ arch }}-yes-green.svg
 {% else %}
@@ -79,6 +76,6 @@ add-on, represents the version number.
 
 [issue]: https://github.com/{{ name }}/issues
 [license-shield]: https://img.shields.io/github/license/{{ name }}.svg
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2023.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-experimental-yellow.svg
 [semver]: http://semver.org/spec/v2.0.0.html

--- a/esphome-dev/config.yaml
+++ b/esphome-dev/config.yaml
@@ -2,7 +2,6 @@
 url: https://next.esphome.io/
 arch:
 - amd64
-- armv7
 - aarch64
 hassio_api: true
 auth_api: true

--- a/esphome/config.yaml
+++ b/esphome/config.yaml
@@ -2,7 +2,6 @@
 url: https://esphome.io/
 arch:
 - amd64
-- armv7
 - aarch64
 hassio_api: true
 auth_api: true

--- a/owserver/config.yaml
+++ b/owserver/config.yaml
@@ -12,8 +12,6 @@ init: false
 arch:
   - amd64
   - aarch64
-  - armhf
-  - armv7
 boot: auto
 uart: true
 options:

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,0 @@
-{
-  "name": "JetHome Add-ons: EDGE !",
-  "url": "https://github.com/jethome-hassio-addons/repository-edge",
-  "maintainer": "Pavel Sokolov <pavel@jethome.ru>"
-}

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,4 @@
+---
+name: "JetHome Add-ons: EDGE !"
+url: https://github.com/jethome-hassio-addons/repository-edge
+maintainer: JetHome Team <dev@jethome.com>


### PR DESCRIPTION
## Summary

- Migrate repository.json to repository.yaml format (HA 2025 standard)
- Update maintainer to JetHome Team <dev@jethome.com>
- Remove deprecated architectures (armv7, armhf, i386) from addon configs
- Update maintenance year to 2026 in README template

## Breaking Changes

Removes support for 32-bit architectures (i386, armhf, armv7) which were deprecated by Home Assistant in December 2025.

## Affected addons

- esphome - removed armv7
- esphome-dev - removed armv7
- owserver - removed armhf, armv7

## Test plan

- [ ] Verify repository is recognized by Home Assistant after merge
- [ ] Verify addons install correctly on amd64
- [ ] Verify addons install correctly on aarch64